### PR TITLE
Fixed to work with python 3.4

### DIFF
--- a/compiler.py
+++ b/compiler.py
@@ -506,7 +506,7 @@ class Compiler:
     #Generate the build script
     src += 'NAME=vecpy_%s.so'%(k.name)
     src += 'rm -f $NAME'
-    src += 'g++ -O3 -fPIC -shared %s -o $NAME %s'%(' '.join(build_flags), Compiler.get_core_file(k))
+    src += 'g++ -O3 -fPIC -shared %s -o $NAME %s  -I$JAVA_HOME/include -I$JAVA_HOME/include/linux'%(' '.join(build_flags), Compiler.get_core_file(k))
     #src += 'nm $NAME | grep " T "'
     #Save code to file
     file_name = 'build.sh'
@@ -544,8 +544,8 @@ class Compiler:
     if Binding.all in options.bindings or Binding.python in options.bindings:
       Compiler.compile_python(kernel, options)
       include_files.append(Compiler.get_python_file(kernel))
-      build_flags.append('-lpython3.3m')
-      build_flags.append('-I/usr/include/python3.3m/')
+      build_flags.append('-lpython3.4m')
+      build_flags.append('-I/usr/include/python3.4m/')
     if Binding.all in options.bindings or Binding.java in options.bindings:
       Compiler.compile_java(kernel, options)
       include_files.append(Compiler.get_java_file(kernel))


### PR DESCRIPTION
Changed compiler.py so it now builds correctly with python 3.4, also explicitly included the Java directorties so it's able to find jni.h for compiling with use for Java.
